### PR TITLE
 [feat]: Implement Auto-Save Logic constraint > 500 words #5

### DIFF
--- a/src/pl/EditorPO.java
+++ b/src/pl/EditorPO.java
@@ -874,7 +874,10 @@ public class EditorPO extends JFrame {
 			int fileId = (int) tableModel.getValueAt(selectedRow, 0);
 			String fileName = (String) tableModel.getValueAt(selectedRow, 1);
 			String content = contentTextArea.getText();
-
+			int wordCount = calculateWordCount(content);
+			if (wordCount <= 500) {
+				return;
+			}
 			if (content == null || content.trim().isEmpty()) {
 				content = "";
 			}


### PR DESCRIPTION
Issue #5 
Implemented a logical constraint in the autoSaveFile() method within EditorPO.java. The system now checks the current word count of the document before triggering a database update.

Technical Details

    Added a conditional check: if (wordCount <= 500) return;

    The Auto-Save thread will now skip the write operation if the content is below the threshold.