### PR TITLE
Introduce command pattern and tests #13

### DIFF
--- a/Testing/business/CommandTest.java
+++ b/Testing/business/CommandTest.java
@@ -1,0 +1,47 @@
+package business;
+
+import bll.*;
+import dal.IFacadeDAO;
+import dto.Documents;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+public class CommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void testExportCommand() {
+        File file = tempDir.resolve("export_test.txt").toFile();
+        String content = "Test content for export";
+        
+        ExportCommand cmd = new ExportCommand(content, file);
+        cmd.execute();
+        
+        assertTrue(cmd.isSuccess());
+        assertTrue(file.exists());
+    }
+
+    @Test
+    public void testImportCommandFailureWithNull() {
+  
+        importCommand cmd = new importCommand(null, new File("nonexistent.txt"), "test.txt");
+        cmd.execute();
+        assertFalse(cmd.isSuccess(), "Should fail gracefully when dependencies are missing");
+    }
+
+    @Test
+    public void testTransliterateCommandStructure() {
+        // Testing that the command pattern is correctly implemented using the interface
+        ICommand cmd = new TransliterateCommand(null, 1, "test"); 
+        assertNotNull(cmd);
+        // We ensure it can be assigned to ICommand (Swappable requirement)
+    }
+}

--- a/src/bll/EditorBO.java
+++ b/src/bll/EditorBO.java
@@ -59,26 +59,9 @@ public class EditorBO implements IEditorBO {
 
 	@Override
 	public boolean importTextFiles(File file, String fileName) {
-		StringBuilder fileContent = new StringBuilder();
-		String fileExtension = getFileExtension(fileName);
-		BufferedReader reader;
-		try {
-			reader = new BufferedReader(new FileReader(file));
-			String line;
-
-			while ((line = reader.readLine()) != null) {
-				fileContent.append(line).append("\n");
-			}
-			reader.close();
-
-			if (fileExtension.equalsIgnoreCase("txt") || fileExtension.equalsIgnoreCase("md5")) {
-				return db.createFileInDB(fileName, fileContent.toString());
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			LOGGER.error(e.getMessage());
-		}
-		return false;
+		importCommand cmd = new importCommand(db, file, fileName);
+		cmd.execute();
+		return cmd.isSuccess();
 	}
 
 	@Override
@@ -105,7 +88,9 @@ public class EditorBO implements IEditorBO {
 
 	@Override
 	public String transliterate(int pageId, String arabicText) {
-		return db.transliterateInDB(pageId, arabicText);
+		TransliterateCommand cmd = new TransliterateCommand(db, pageId, arabicText);
+		cmd.execute();
+		return cmd.getResult();
 	}
 
 	@Override

--- a/src/bll/ExportCommand.java
+++ b/src/bll/ExportCommand.java
@@ -1,0 +1,30 @@
+package bll;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ExportCommand implements ICommand {
+    private String content;
+    private File targetFile;
+    private boolean success;
+
+    public ExportCommand(String content, File targetFile) {
+        this.content = content;
+        this.targetFile = targetFile;
+    }
+
+    @Override
+    public void execute() {
+        try (FileWriter writer = new FileWriter(targetFile)) {
+            writer.write(content);
+            success = true;
+        } catch (IOException e) {
+            success = false;
+        }
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+}

--- a/src/bll/ICommand.java
+++ b/src/bll/ICommand.java
@@ -1,0 +1,6 @@
+// done for sepration of command
+package bll;
+
+public interface ICommand {
+    void execute();
+}

--- a/src/bll/TransliterateCommand.java
+++ b/src/bll/TransliterateCommand.java
@@ -1,0 +1,25 @@
+package bll;
+
+import dal.IFacadeDAO;
+
+public class TransliterateCommand implements ICommand {
+    private IFacadeDAO db;
+    private int pageId;
+    private String text;
+    private String result;
+
+    public TransliterateCommand(IFacadeDAO db, int pageId, String text) {
+        this.db = db;
+        this.pageId = pageId;
+        this.text = text;
+    }
+
+    @Override
+    public void execute() {
+        result = db.transliterateInDB(pageId, text);
+    }
+
+    public String getResult() {
+        return result;
+    }
+}

--- a/src/bll/importCommand.java
+++ b/src/bll/importCommand.java
@@ -1,0 +1,37 @@
+package bll;
+
+import dal.IFacadeDAO;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+
+public class importCommand implements ICommand {
+    private IFacadeDAO db;
+    private File file;
+    private String fileName;
+    private boolean success;
+
+    public importCommand(IFacadeDAO db, File file, String fileName) {
+        this.db = db;
+        this.file = file;
+        this.fileName = fileName;
+    }
+
+    @Override
+    public void execute() {
+        StringBuilder fileContent = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                fileContent.append(line).append("\n");
+            }
+            success = db.createFileInDB(fileName, fileContent.toString());
+        } catch (Exception e) {
+            success = false;
+        }
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+}


### PR DESCRIPTION
fixes issue at #13 
Add a lightweight ICommand interface and three command implementations: importCommand, ExportCommand, and TransliterateCommand. Refactor EditorBO to delegate importTextFiles and transliterate operations to the new command objects (using command.execute() and returning command results/success). Add CommandTest unit tests that verify ExportCommand writes a file, importCommand fails gracefully with null dependencies, and that TransliterateCommand conforms to the ICommand structure. This decouples file/db operations from EditorBO, improves testability, and centralizes I/O/error handling within command objects.